### PR TITLE
Add a note about the order of the components of the OBB quaternion

### DIFF
--- a/docs/1.6/obb.cmn.md
+++ b/docs/1.6/obb.cmn.md
@@ -11,7 +11,7 @@ Oriented bounding box
 | --- | --- | --- |
 | **center** | number[3] | The center point of the oriented bounding box. For a global scene, i.e. XY coordinate system in WGS1984, center is in longitude of decimal degrees, latitude of decimal degrees, elevation in meters. |
 | **halfSize** | number[3] | Half size of the oriented bounding box in spatial reference units (or meters for global scenes). |
-| **quaternion** | number[4] | Orientation of the oriented bounding box as a 4-component quaternion. For global scene, quaternion is in Earth-Centric-Earth-Fixed (ECEF) Cartesian space. ( Z+ : North, Y+ : East, X+: lon=lat=0.0). |
+| **quaternion** | number[4] | Orientation of the oriented bounding box as a 4-component quaternion. For global scene, quaternion is in Earth-Centric-Earth-Fixed (ECEF) Cartesian space. ( Z+ : North, Y+ : East, X+: lon=lat=0.0). The quaternion components are in the order x, y, z, w. |
 
 *Note: properties in **bold** are required*
 

--- a/docs/1.7/obb.cmn.md
+++ b/docs/1.7/obb.cmn.md
@@ -11,7 +11,7 @@ Oriented bounding box
 | --- | --- | --- |
 | **center** | number[3] | The center point of the oriented bounding box. For a global scene, i.e. XY coordinate system in WGS1984, center is in longitude of decimal degrees, latitude of decimal degrees, elevation in meters. |
 | **halfSize** | number[3] | Half size of the oriented bounding box in spatial reference units (or meters for global scenes). |
-| **quaternion** | number[4] | Orientation of the oriented bounding box as a 4-component quaternion. For global scene, quaternion is in Earth-Centric-Earth-Fixed (ECEF) Cartesian space. ( Z+ : North, Y+ : East, X+: lon=lat=0.0). |
+| **quaternion** | number[4] | Orientation of the oriented bounding box as a 4-component quaternion. For global scene, quaternion is in Earth-Centric-Earth-Fixed (ECEF) Cartesian space. ( Z+ : North, Y+ : East, X+: lon=lat=0.0). The quaternion components are in the order x, y, z, w. |
 
 *Note: properties in **bold** are required*
 

--- a/docs/2.0/obb.cmn.md
+++ b/docs/2.0/obb.cmn.md
@@ -11,7 +11,7 @@ Oriented bounding box
 | --- | --- | --- |
 | **center** | number[3] | The center point of the oriented bounding box. For a global scene, i.e. XY coordinate system in WGS1984, center is in longitude of decimal degrees, latitude of decimal degrees, elevation in meters. |
 | **halfSize** | number[3] | Half size of the oriented bounding box in spatial reference units (or meters for global scenes). |
-| **quaternion** | number[4] | Orientation of the oriented bounding box as a 4-component quaternion. For global scene, quaternion is in Earth-Centric-Earth-Fixed (ECEF) Cartesian space. ( Z+ : North, Y+ : East, X+: lon=lat=0.0). |
+| **quaternion** | number[4] | Orientation of the oriented bounding box as a 4-component quaternion. For global scene, quaternion is in Earth-Centric-Earth-Fixed (ECEF) Cartesian space. ( Z+ : North, Y+ : East, X+: lon=lat=0.0). The quaternion components are in the order x, y, z, w. |
 
 *Note: properties in **bold** are required*
 


### PR DESCRIPTION
Sometimes the `w` component is first, sometimes it's last, so it's best to make it clear in the documentation which one i3s expects.