### PR TITLE
update ArcGIS Earth consuming version and update name format of jpg texture example

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ This table reflects the current versions of the ArcGIS Clients.
   <tr>
     <td>Point</td>
     <td></td>
-    <td></td>
-    <td></td>
+    <td align="middle"><img alt="supported" src="format/images/checkmark.png"></td>
+    <td>1.10</td>
     <td></td>
     <td></td>
     <td></td>
@@ -318,8 +318,8 @@ This table reflects the current versions of the ArcGIS Clients.
   <tr>
     <td>Point Cloud</td>
     <td></td>
-    <td></td>
-    <td></td>
+    <td align="middle"><img alt="supported" src="format/images/checkmark.png"></td>
+    <td>1.10</td>
     <td></td>
     <td></td>
     <td></td>

--- a/docs/1.7/textureDefinition.cmn.md
+++ b/docs/1.7/textureDefinition.cmn.md
@@ -41,7 +41,7 @@ Part of [sharedResource](sharedResource.cmn.md) that is deprecated with 1.7.
         "size": 512,
         "pixelInWorldUnits": 0,
         "href": [
-          "../textures/0_0",
+          "../textures/0",
           "../textures/0_0_1"
         ],
         "byteOffset": [

--- a/docs/1.7/textureDefinitionInfo.cmn.md
+++ b/docs/1.7/textureDefinitionInfo.cmn.md
@@ -43,7 +43,7 @@ Part of [sharedResource](sharedResource.cmn.md) that is deprecated with 1.7.
       "size": 512,
       "pixelInWorldUnits": 0,
       "href": [
-        "../textures/0_0",
+        "../textures/0",
         "../textures/0_0_1"
       ],
       "byteOffset": [

--- a/docs/1.8/textureDefinition.cmn.md
+++ b/docs/1.8/textureDefinition.cmn.md
@@ -42,7 +42,7 @@ Part of [sharedResource](sharedResource.cmn.md) that is deprecated with 1.7.
         "size": 2048,
         "pixelInWorldUnits": 0,
         "href": [
-          "../textures/0_0",
+          "../textures/0",
           "../textures/0_0_1",
           "../textures/1"
         ],

--- a/docs/1.8/textureDefinitionInfo.cmn.md
+++ b/docs/1.8/textureDefinitionInfo.cmn.md
@@ -44,7 +44,7 @@ Part of [sharedResource](sharedResource.cmn.md) that is deprecated with 1.7.
       "size": 2048,
       "pixelInWorldUnits": 0,
       "href": [
-        "../textures/0_0",
+        "../textures/0",
         "../textures/0_0_1",
         "../textures/1"
       ],


### PR DESCRIPTION
update ArcGIS Earth consuming version for point and point cloud
- ArcGIS Earth supported consuming Point and Point Cloud [from v1.10](https://doc.arcgis.com/en/arcgis-earth/get-started/what-s-new-for-1-10.htm).

update name format of jpeg texture example to make the name format clear
- Because the name format of jpg/png must be `0` according to `textureSetDefinitionFormat` ([1.8](https://github.com/Esri/i3s-spec/blob/master/docs/1.8/textureSetDefinitionFormat.cmn.md), [1.7](https://github.com/Esri/i3s-spec/blob/master/docs/1.7/textureSetDefinitionFormat.cmn.md)), update other examples related to the name of jpg to clear the misuse